### PR TITLE
Allow multiple links with custom link field

### DIFF
--- a/lib/redmine/field_format.rb
+++ b/lib/redmine/field_format.rb
@@ -323,24 +323,46 @@ module Redmine
 
     class LinkFormat < StringFormat
       add 'link'
+      self.multiple_supported = true
       self.searchable_supported = false
       self.form_partial = 'custom_fields/formats/link'
 
       def formatted_value(view, custom_field, value, customized=nil, html=false)
-        if html
-          if custom_field.url_pattern.present?
-            url = url_from_pattern(custom_field, value, customized)
-          else
-            url = value.to_s
-            unless url =~ %r{\A[a-z]+://}i
-              # no protocol found, use http by default
-              url = "http://" + url
+        values = value.is_a?(Array) ? value : [value]
+        links = []
+
+        values.each do |val|
+          if html
+            if custom_field.url_pattern.present?
+              url = url_from_pattern(custom_field, val, customized)
+            else
+              url = val.to_s
+              unless url =~ %r{\A[a-z]+://}i
+                # no protocol found, use http by default
+                url = "http://" + url
+              end
             end
+            links << view.link_to(val.to_s, url)
+          else
+            links << val.to_s
           end
-          view.link_to value.to_s, url
-        else
-          value.to_s
         end
+
+        links.length == 1 ? links[0] : links
+      end
+
+      def edit_tag(view, tag_id, tag_name, custom_value, options={})
+        if custom_value.value.is_a?(String)
+          view_response = view.text_field_tag(tag_name, custom_value.value, options.merge(:id => tag_id, :size => 10))
+        else
+          view_response = view.text_field_tag(tag_name, '', options.merge(:id => tag_id, :size => 10))
+
+          custom_value.value.each do |value|
+            view_response += view.text_field_tag(tag_name, value, options.merge(:id => tag_id, :size => 10))
+          end
+        end
+
+        view_response
       end
     end
 

--- a/test/unit/lib/redmine/field_format/link_format_test.rb
+++ b/test/unit/lib/redmine/field_format/link_format_test.rb
@@ -87,4 +87,12 @@ class Redmine::LinkFieldFormatTest < ActionView::TestCase
     assert_equal "foo.bar", field.format.formatted_custom_value(self, custom_value, false)
     assert_equal '<a href="http://foo.bar">foo.bar</a>', field.format.formatted_custom_value(self, custom_value, true)
   end
+
+  def test_link_field_with_multiple_values_returns_array_of_links
+    field = IssueCustomField.new(:field_format => 'link')
+    custom_value = CustomValue.new(:custom_field => field, :customized => Issue.new, :value => ["foo.bar", "bar.foo"])
+
+    assert_equal ["foo.bar", "bar.foo"], field.format.formatted_custom_value(self, custom_value, false)
+    assert_equal ['<a href="http://foo.bar">foo.bar</a>', '<a href="http://bar.foo">bar.foo</a>'], field.format.formatted_custom_value(self, custom_value, true)
+  end
 end


### PR DESCRIPTION
I realize this is a one-off patch that I am more than happy to try and contribute to upstream Redmine. However, given what it will give us with respect to issue and PR management I'd like to get it in for our use sooner than the cycle it may take to get it into upstream Redmine. I didn't test with a replica DB, but I did use this development container (https://github.com/Katello/katello-deploy/pull/185) to mount Redmine, add the changes here, add a custom Link field with multiple values set to true and create some issues with multiple links through the UI and modify them via the API.