### PR TITLE
Fixed gmail threading

### DIFF
--- a/app/models/mailer.rb
+++ b/app/models/mailer.rb
@@ -41,7 +41,7 @@ class Mailer < ActionMailer::Base
     @issue_url = url_for(:controller => 'issues', :action => 'show', :id => issue)
     mail :to => to_users.map(&:mail),
       :cc => cc_users.map(&:mail),
-      :subject => "[#{issue.project.name} - #{issue.tracker.name} ##{issue.id}] (#{issue.status.name}) #{issue.subject}"
+      :subject => "[#{issue.project.name} - #{issue.tracker.name} ##{issue.id}] #{issue.subject}"
   end
 
   # Notifies users about a new issue


### PR DESCRIPTION
RedMine is unusable using gmail as all threads are broken. Users report this
change might help:

http://www.redmine.org/issues/3660

I don't have currently time to push such a change upstream, but I am wondering
if folks could live without status in subject, which is causing the broken
threads there.