### PR TITLE
use CustomFieldValue in multiple links test

### DIFF
--- a/test/unit/lib/redmine/field_format/link_format_test.rb
+++ b/test/unit/lib/redmine/field_format/link_format_test.rb
@@ -97,9 +97,9 @@ class Redmine::LinkFieldFormatTest < ActionView::TestCase
 
   def test_link_field_with_multiple_values_returns_array_of_links
     field = IssueCustomField.new(:field_format => 'link')
-    custom_value = CustomValue.new(:custom_field => field, :customized => Issue.new, :value => ["foo.bar", "bar.foo"])
+    custom_value = CustomFieldValue.new(:custom_field => field, :customized => Issue.new, :value => ["foo.bar", "bar.foo"])
 
     assert_equal ["foo.bar", "bar.foo"], field.format.formatted_custom_value(self, custom_value, false)
-    assert_equal ['<a href="http://foo.bar">foo.bar</a>', '<a href="http://bar.foo">bar.foo</a>'], field.format.formatted_custom_value(self, custom_value, true)
+    assert_equal ['<a class="external" href="http://foo.bar">foo.bar</a>', '<a class="external" href="http://bar.foo">bar.foo</a>'], field.format.formatted_custom_value(self, custom_value, true)
   end
 end


### PR DESCRIPTION
this makes the test pass as it now correctly detects that the field supports the multiple property